### PR TITLE
Implement Async I2C peripheral and example

### DIFF
--- a/e310x-hal/src/asynch.rs
+++ b/e310x-hal/src/asynch.rs
@@ -7,6 +7,7 @@
 
 pub mod delay;
 pub mod digital;
+pub mod i2c;
 pub mod prelude;
 
 // HAL Async Utilities

--- a/e310x-hal/src/asynch/i2c.rs
+++ b/e310x-hal/src/asynch/i2c.rs
@@ -1,0 +1,159 @@
+//! # I2C Async API
+//! # Note
+//!
+//! Implementation of the Async Embedded HAL I2C functionality.
+//!
+use crate::asynch::poll_fn;
+use crate::i2c::{I2c, I2cX};
+use core::cell::RefCell;
+use core::task::{Poll, Waker};
+use critical_section::Mutex;
+use e310x::I2c0;
+use embedded_hal::i2c::{ErrorKind, NoAcknowledgeSource, Operation};
+use embedded_hal_async::i2c;
+
+const FLAG_READ: u8 = 1;
+const FLAG_WRITE: u8 = 0;
+static I2C_WAKER: Mutex<RefCell<Option<Waker>>> = Mutex::new(RefCell::new(None));
+
+/// Interrupt handler function for I2C
+#[inline]
+fn on_irq() {
+    // Wake the waker if it exists
+    critical_section::with(|cs| {
+        let mut i2cwaker = I2C_WAKER.borrow_ref_mut(cs);
+        if let Some(waker) = i2cwaker.take() {
+            waker.wake();
+        }
+    });
+    // Clear the interrupt
+    let i2c = unsafe { I2c0::steal() };
+    i2c.clear_interrupt();
+}
+
+impl<I2C: I2cX, PINS> I2c<I2C, PINS> {
+    /// Wait until the I2C bus is idle.
+    async fn wait_idle_async(&mut self) {
+        poll_fn(|cx| {
+            self.disable_interrupt();
+            if self.is_idle() {
+                Poll::Ready(())
+            } else {
+                // Register the waker to be notified when an interrupt occurs
+                critical_section::with(|cs| {
+                    let mut i2cwaker = I2C_WAKER.borrow_ref_mut(cs);
+                    *i2cwaker = Some(cx.waker().clone())
+                });
+                // Turn on i2c interrupt
+                self.enable_interrupt();
+                Poll::Pending
+            }
+        })
+        .await;
+    }
+
+    /// Acknowledge the I2C interrupt.
+    async fn ack_interrupt_async(&mut self) -> Result<(), ErrorKind> {
+        poll_fn(|cx| {
+            self.disable_interrupt();
+            let result = self.ack_interrupt();
+            match result {
+                Ok(()) => Poll::Ready(Ok(())),
+                Err(nb::Error::WouldBlock) => {
+                    // Register the waker to be notified when an interrupt occurs
+                    critical_section::with(|cs| {
+                        let mut i2cwaker = I2C_WAKER.borrow_ref_mut(cs);
+                        *i2cwaker = Some(cx.waker().clone())
+                    });
+                    // Turn on i2c interrupt
+                    self.enable_interrupt();
+                    Poll::Pending
+                }
+                Err(nb::Error::Other(e)) => Poll::Ready(Err(e)),
+            }
+        })
+        .await
+    }
+
+    /// Asynchronously wait for a write operation to complete.
+    async fn wait_for_write_async(&mut self, source: NoAcknowledgeSource) -> Result<(), ErrorKind> {
+        self.ack_interrupt_async().await?;
+        if self.read_sr().rx_ack().bit_is_set() {
+            self.set_stop();
+            Err(ErrorKind::NoAcknowledge(source))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Asynchronously wait for a read operation to complete.
+    async fn wait_for_read_async(&mut self) -> Result<(), ErrorKind> {
+        self.ack_interrupt_async().await
+    }
+}
+
+impl<I2C: I2cX, PINS> i2c::I2c for I2c<I2C, PINS> {
+    async fn transaction(
+        &mut self,
+        address: u8,
+        operations: &mut [i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        let n_ops = operations.len();
+        if n_ops == 0 {
+            return Ok(());
+        }
+
+        self.wait_idle_async().await;
+        self.reset();
+
+        // we use this flag to detect when we need to send a (repeated) start
+        let mut last_op_was_read = match &operations[0] {
+            Operation::Read(_) => false,
+            Operation::Write(_) => true,
+        };
+
+        for (i, operation) in operations.iter_mut().enumerate() {
+            match operation {
+                Operation::Write(bytes) => {
+                    // Send write command
+                    self.write_txr((address << 1) + FLAG_WRITE);
+                    self.trigger_write(last_op_was_read, false);
+                    self.wait_for_write_async(NoAcknowledgeSource::Address)
+                        .await?;
+                    last_op_was_read = false;
+
+                    // Write bytes
+                    let n_bytes = bytes.len();
+                    for (j, byte) in bytes.iter().enumerate() {
+                        self.write_txr(*byte);
+                        self.trigger_write(false, (i == n_ops - 1) && (j == n_bytes - 1));
+                        self.wait_for_write_async(NoAcknowledgeSource::Data).await?;
+                    }
+                }
+                Operation::Read(buffer) => {
+                    // Send read command
+                    self.write_txr((address << 1) + FLAG_READ);
+                    self.trigger_write(!last_op_was_read, false);
+                    self.wait_for_write_async(NoAcknowledgeSource::Address)
+                        .await?;
+                    last_op_was_read = true;
+
+                    // Read bytes
+                    let n_bytes = buffer.len();
+                    for (j, byte) in buffer.iter_mut().enumerate() {
+                        self.trigger_read(j == n_bytes - 1, (i == n_ops - 1) && (j == n_bytes - 1));
+                        self.wait_for_read_async().await?;
+                        *byte = self.read_rxr();
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Interrupt Handler
+#[riscv_rt::external_interrupt(e310x::interrupt::ExternalInterrupt::I2C0)]
+fn i2c_handler() {
+    on_irq();
+}

--- a/e310x-hal/src/asynch/prelude.rs
+++ b/e310x-hal/src/asynch/prelude.rs
@@ -1,3 +1,4 @@
 //! Prelude
 pub use embedded_hal_async::delay::DelayNs as _eha_DelayNs;
 pub use embedded_hal_async::digital::Wait as _eha_Wait;
+pub use embedded_hal_async::i2c::I2c as _eha_I2c;

--- a/hifive1-async-examples/Cargo.toml
+++ b/hifive1-async-examples/Cargo.toml
@@ -14,5 +14,12 @@ riscv-rt = { version = "0.15.0", features = ["single-hart"] }
 panic-halt = "1.0.0"
 semihosting = { version = "0.1",  features = ["stdio", "panic-handler"] }
 
+#RTT dependencies
+rtt-target = "0.6.1"
+panic-rtt-target = "0.2.0"
+
+# Specific devices
+embedded-devices = { version = "0.9.13", features = ["async", "bosch-bme280"] }
+uom = {version = "0.36.0", default-features = false, features = ["f32", "si"]}
 [features]
 v-trap = ["hifive1/v-trap"]

--- a/hifive1-async-examples/examples/i2c_bme280.rs
+++ b/hifive1-async-examples/examples/i2c_bme280.rs
@@ -1,0 +1,88 @@
+//! Sample example for the MAX3010x pulse oximeter and heart rate sensor
+//! using the I2C interface.
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embedded_devices::devices::bosch::bme280::registers::{IIRFilter, Oversampling};
+use embedded_devices::devices::bosch::bme280::{BME280Async, Configuration, address::Address};
+use hifive1::{
+    clock,
+    hal::{
+        DeviceResources,
+        asynch::delay::Delay,
+        asynch::prelude::*,
+        e310x::interrupt::Hart,
+        i2c::{I2c, Speed},
+        prelude::*,
+    },
+    pin, sprintln,
+};
+use uom::num_traits::ToPrimitive;
+use uom::si::thermodynamic_temperature::degree_celsius;
+extern crate panic_halt;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) -> ! {
+    let dr = DeviceResources::take().unwrap();
+    let p = dr.peripherals;
+    let cp = dr.core_peripherals;
+    let pins = dr.pins;
+
+    // Configure clocks
+    let clocks = clock::configure(p.PRCI, p.AONCLK, 320.mhz().into());
+
+    // Configure UART for stdout
+    hifive1::stdout::configure(
+        p.UART0,
+        pin!(pins, uart0_tx),
+        pin!(pins, uart0_rx),
+        115_200.bps(),
+        clocks,
+    );
+
+    // I2C configuration
+    let sda = pin!(pins, i2c0_sda).into_iof0();
+    let scl = pin!(pins, i2c0_scl).into_iof0();
+    let i2c = I2c::new(p.I2C0, sda, scl, Speed::Normal, clocks);
+
+    // Get the MTIMER peripheral from CLINT
+    let mtimer = cp.clint.mtimer();
+    mtimer.disable();
+    let (mtimecmp, mtime) = (mtimer.mtimecmp(Hart::H0), mtimer.mtime());
+    mtime.write(0);
+    mtimecmp.write(u64::MAX);
+    let mut delay = Delay::new(mtimer);
+    const STEP: u32 = 1000; // 1s
+
+    // Enable interrupts
+    let plic = cp.plic;
+    let ctx = plic.ctx0();
+    unsafe {
+        ctx.enables().disable_all::<ExternalInterrupt>();
+        i2c.enable_exti();
+        ctx.threshold().set_threshold(Priority::P0);
+        riscv::interrupt::enable();
+        plic.enable();
+    };
+
+    //BME280 sensor configuration
+    let mut bme280 = BME280Async::new_i2c(i2c, Address::Primary);
+    bme280.init(&mut delay).await.unwrap();
+    bme280
+        .configure(Configuration {
+            temperature_oversampling: Oversampling::X_16,
+            pressure_oversampling: Oversampling::X_16,
+            humidity_oversampling: Oversampling::X_16,
+            iir_filter: IIRFilter::Disabled,
+        })
+        .await
+        .unwrap();
+    loop {
+        let measurements = bme280.measure(&mut delay).await.unwrap();
+        let temp = measurements.temperature.get::<degree_celsius>().to_f32();
+        sprintln!("Current temperature: {:?} Celsius", temp.unwrap());
+        delay.delay_ms(STEP).await;
+    }
+}

--- a/hifive1-async-examples/examples/led_blink.rs
+++ b/hifive1-async-examples/examples/led_blink.rs
@@ -9,10 +9,7 @@ use embassy_executor::Spawner;
 use hifive1::{
     Led, clock,
     hal::{
-        DeviceResources,
-        asynch::delay::Delay,
-        asynch::prelude::*,
-        e310x::{Clint, interrupt::Hart},
+        DeviceResources, asynch::delay::Delay, asynch::prelude::*, e310x::interrupt::Hart,
         prelude::*,
     },
     pin, sprintln,


### PR DESCRIPTION
Async implementation of I2C along with changes in the blocking I2C in order to reuse some of its functions in the Async implementation and make user-friendly interrupt handling I2C functions.